### PR TITLE
fix(follow): 검색 API Request 수정

### DIFF
--- a/src/app/Follow/followController.js
+++ b/src/app/Follow/followController.js
@@ -54,7 +54,7 @@ exports.getAllFollow = async function(req, res) {
  exports.searchFollows = async function(req, res) {
     const userIdFromJWT = req.verifiedToken.userIdx;
     const follower = req.params.follower;
-    const nickName = req.body.nickName;
+    const nickName = req.query.nickName;
     const searchedFollowList = await followProvider.searchFollowList(follower, nickName);
 
     if (userIdFromJWT != follower)
@@ -78,7 +78,7 @@ exports.getAllFollow = async function(req, res) {
  exports.searchFollowEmail = async function(req, res) {
     const userIdFromJWT = req.verifiedToken.userIdx;
     const follower = req.params.follower;
-    const email = req.body.email;
+    const email = req.query.email;
     const searchedFollow = await followProvider.retrieveFollowEmail(follower, email);
 
     if (userIdFromJWT != follower)


### PR DESCRIPTION
# ❗️Fix Request Error
"GET method must not have a body" 오류는 HTTP GET 요청이 바디(body)를 가질 수 없기 때문에 발생합니다. 즉, GET 요청에는 데이터를 바디에 담아 보낼 수 없습니다. 따라서, _**GET 요청을 보낼 때는 바디(body) 대신에 쿼리 파라미터(query parameter)를 사용해야 합니다.**_ 